### PR TITLE
Adjust promotion image size on mobile

### DIFF
--- a/packages/common/components/blocks/content/promotion-half.marko
+++ b/packages/common/components/blocks/content/promotion-half.marko
@@ -82,7 +82,7 @@ $ const textAdButtonLinkStyle = {
     <tr>
       <td valign="top">
         <for|node| of=nodes>
-          <common-table width="280" style="border-collapse:collapse;" align=align padding=10 spacing=0>
+          <common-table class="main" width="280" style="border-collapse:collapse;" align=align padding=10 spacing=0>
             <tr>
               <td bgcolor="#ecedee">
                 <marko-core-obj-text obj=node field="name">
@@ -101,7 +101,6 @@ $ const textAdButtonLinkStyle = {
                         <marko-newsletter-imgix
                           src=image.src
                           alt=image.alt
-                          class="sponsored"
                           options={ w: 150 }
                           attrs={ border: 0, width: 150 }
                         >

--- a/packages/common/components/blocks/content/promotion-half.marko
+++ b/packages/common/components/blocks/content/promotion-half.marko
@@ -101,8 +101,8 @@ $ const textAdButtonLinkStyle = {
                         <marko-newsletter-imgix
                           src=image.src
                           alt=image.alt
-                          options={ w: 300 }
                           class="sponsored"
+                          options={ w: 150 }
                           attrs={ border: 0, width: 150 }
                         >
                           <@link href=node.siteContext.url target="_blank" />

--- a/packages/common/components/static-styles.marko
+++ b/packages/common/components/static-styles.marko
@@ -82,7 +82,7 @@
       padding-right: 0 !important;
     }
     .sponsored {
-      width: 300px !important;
+      width: 280px !important;
     }
     .mobileHide {
       display: none !important;


### PR DESCRIPTION
<img width="428" alt="Screen Shot 2021-05-27 at 7 08 19 PM" src="https://user-images.githubusercontent.com/2855198/119912550-4822d380-bf21-11eb-9b3e-c6f659375388.png">
