### PR TITLE
Remove uri for ‘mdd’ newsletter email-x ad slot

### DIFF
--- a/tenants/multi/config/email-x.js
+++ b/tenants/multi/config/email-x.js
@@ -273,7 +273,6 @@ config
       id: '622119fa5d6c0a35b18a5cad',
       width: 600,
       height: 100,
-      uri: 'https://email-serve.medicaldesigndevelopment.com',
     },
   ]);
 


### PR DESCRIPTION
Ad shows now:
<img width="854" alt="Screen Shot 2022-03-16 at 2 54 04 PM" src="https://user-images.githubusercontent.com/64623209/158678543-8ef42af7-0a34-4fb7-ba02-ed556b9d3708.png">
