### PR TITLE
Add subscribe-url prop to footer component

### DIFF
--- a/packages/common/components/blocks/footer/index.marko
+++ b/packages/common/components/blocks/footer/index.marko
@@ -13,6 +13,7 @@ $ const footerText = defaultValue(input.footerText, {
 
 $ const { website, config, req } = out.global;
 
+$ const subscrbeUrl = defaultValue(input.subscribeUrl, `${website.get("origin")}/newsletter-signup`);
 $ const unsubscribeId = defaultValue(input.unsubscribeCloudPageId, 204);
 $ const unsubscribeUrl = `%%=RedirectTo(CloudPagesURL(${unsubscribeId}, 'sk', _subscriberkey, 'p', listid, 'ln', _listname, 'j', jobid, 'e', _emailid, 'en', emailname_, 'de', _DataSourceName))=%%`;
 
@@ -33,7 +34,7 @@ $ const esp = query.esp || config.get("defaultEsp");
               |
               <a href=`${website.get("origin")}/contact-us` target="_blank" style=footerText>Contact Us</a>
               |
-              <a href=`${website.get("origin")}/newsletter-signup` target="_blank" style=footerText>Subscribe</a>
+              <a href=subscrbeUrl target="_blank" style=footerText>Subscribe</a>
               |
               <a href=`${advertisePageLink}` target="_blank" style=footerText>Advertise</a>
             </div>

--- a/packages/common/components/blocks/footer/marko.json
+++ b/packages/common/components/blocks/footer/marko.json
@@ -8,6 +8,7 @@
     "@please-contact-email" : "string",
     "@please-contact-name" : "string",
     "@preference-page-link" : "string",
-    "@advertise-page-link" : "string"
+    "@advertise-page-link" : "string",
+    "@subscribe-url": "string"
   }
 }

--- a/tenants/multi/templates/today-medical-design-development.marko
+++ b/tenants/multi/templates/today-medical-design-development.marko
@@ -127,6 +127,7 @@ $ const socialMediaProviders = config.getAsArray('mdd.socialMediaLinks');
       company-name="Lynch Media"
       preference-page-link="https://lynchmedia.dragonforms.com/loading.do?omedasite=CEN_prefs"
       advertise-page-link="https://ien.formstack.com/forms/advertise_with_lynch_media"
+      subscribe-url="https://lynchmedia.dragonforms.com/loading.do?omedasite=cenmeddesdev_signup"
     />
 
   </@body>


### PR DESCRIPTION
This allows for an individual eNL to override the default(`${website.get("origin")}/newsletter-signup`) to be overwritten.