### PR TITLE
Create TIM Podcast newsletters

### DIFF
--- a/tenants/multi/templates/design-development-weekly-tim-podcast.marko
+++ b/tenants/multi/templates/design-development-weekly-tim-podcast.marko
@@ -1,0 +1,128 @@
+import contentList from "@industrial-media/common/graphql/fragments/content-list";
+
+$ const { website, config } = out.global;
+$ const { newsletter, date, dateInfo } = data;
+$ const primaryColor = "#00b3e3";
+$ const socialMediaProviders = config.getAsArray('ddt.socialMediaLinks');
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-static-styles />
+  </@head>
+  <@body style="margin: 0px !important;">
+    <tenant-banner-element
+      newsletter=newsletter
+      date=date
+      date-info=dateInfo
+    />
+
+    <!-- Header -->
+    <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td>&nbsp;</td>
+      </tr>
+      <tr style="background-color:#ffffff">
+        <td align="left">
+          <common-table width="300" border="0" padding=0 spacing=0 align="left" class="main" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;">
+            <tr>
+              <td>
+                <marko-newsletter-imgix
+                  src="/files/base/indm/all/image/static/logos/TIM_Final_DDT.jpeg"
+                  alt="DDT Today"
+                  options={ w: 340, h: 100 }
+                  class="main"
+                  attrs={ border: 0, width: 340}
+                >
+                  <@link href=website.get("origin") target="_blank" />
+                </marko-newsletter-imgix>
+              </td>
+            </tr>
+          </common-table>
+          <common-table width="290" border="0" padding=5 spacing=0 align="right" class="mobileHide" style="padding-top:10px;">
+            <tr>
+              <td height="20" align="right">
+                <common-table width="100%" border="0" spacing=0 padding=0>
+                  <tr style="text-decoration: none !important; font-size: 11px; font-family: Arial, Helvetica, sans-serif; color: #000000; font-weight: bold;">
+                    <td align="right" style="color:#000000; padding-right:20px;">
+                      ${date.format("MMMM DD, YYYY")}
+                    </td>
+                  </tr>
+                </common-table>
+              </td>
+            </tr>
+            <tr>
+              <td align="right" valign="bottom">
+                <for|socialLinks| of=socialMediaProviders>
+                  <marko-newsletter-imgix
+                    src=`/files/base/newsletter/${socialLinks.provider}-black-round.png`
+                    alt=socialLinks.provider
+                    options={ w: 40 }
+                    attrs={ border: 0, width: 40 }
+                  >
+                    <@link href=socialLinks.href title=socialLinks.title target="_blank" />
+                  </marko-newsletter-imgix>
+                  &nbsp;&nbsp;&nbsp;
+                </for>
+              </td>
+            </tr>
+          </common-table>
+        </td>
+      </tr>
+      <tr>
+        <td><hr></td>
+      </tr>
+      <tr>
+        <td>&nbsp;</td>
+      </tr>
+    </common-table>
+
+    <!-- Content -->
+    <common-featured-full-block
+      section-id=86465,
+      limit=1,
+      title="FEATURED STORY",
+      date=date,
+      newsletter=newsletter,
+      primary-color=primaryColor,
+      hr-below=true,
+    />
+
+    <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td>
+          <common-featured-half-block
+            section-id=86464,
+            limit=2,
+            date=date,
+            newsletter=newsletter,
+            primary-color=primaryColor,
+            align="left",
+          />
+          <common-promotion-half-block
+            section-id=86467,
+            limit=2,
+            date=date,
+            primary-color=primaryColor,
+            newsletter=newsletter,
+            align="right",
+          />
+        </td>
+      </tr>
+    </common-table>
+
+    <common-feed-full-block
+      section-id=86466,
+      date=date,
+      newsletter=newsletter,
+      primary-color=primaryColor,
+    />
+
+    <!-- Footer/OptOut -->
+    <common-default-footer-block />
+
+  </@body>
+</marko-newsletter-root>

--- a/tenants/multi/templates/fm-weekly-tim-podcast.marko
+++ b/tenants/multi/templates/fm-weekly-tim-podcast.marko
@@ -1,0 +1,418 @@
+import contentList from "@industrial-media/common/graphql/fragments/content-list";
+import waterMarkDisplay from "@industrial-media/common/utils/watermark-display";
+
+$ const { website } = out.global;
+$ const { newsletter, date, dateInfo } = data;
+$ const primaryColor = "#dc0607";
+$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: normal;";
+$ const titleStyle = "text-decoration: none !important; font-size: 14px; font-family: Arial, Helvetica, sans-serif; color: #000000; text-align: left; font-weight: bold;";
+$ const contentLinkStyle = {
+  "text-decoration": "none",
+  "text-align": "left",
+  "text-decoration": "none !important",
+  "font-size": "16px",
+  "font-family": "Arial, Helvetica, sans-serif",
+  "color": primaryColor,
+  "font-weight": "bold"
+};
+$ const teaserStyle = {
+  "text-decoration": "none !important",
+  "font-size": "13px",
+  "font-family": "Arial, Helvetica, sans-serif",
+  "color": "#666666",
+  "font-weight": "normal",
+  "text-align": "left",
+  "margin-top": "5px !important",
+  "line-height": "1.2em",
+};
+$ const textAdCopyStyle = {
+  "font-family": "Arial, Helvetica, sans-serif",
+  "font-size": "12px",
+  "color": "#000000",
+  "text-align": "left",
+  "line-height": "18px",
+  "margin-top": "5px !important",
+};
+$ const textAdButtonStyle = "background:#3B579D; padding-top:10px; padding-left:10px; padding-right:10px; padding-bottom:10px;";
+$ const textAdButtonLinkStyle = {
+  "text-decoration": "none !important",
+  "font" : "bold 16px/18px Arial, Helvetica, sans-serif",
+  "background": "#3B579D",
+  "color": "#ffffff",
+  "margin-top": "10px",
+};
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-static-styles />
+  </@head>
+  <@body style="margin: 0px !important;">
+    <tenant-banner-element
+      newsletter=newsletter
+      date=date
+      date-info=dateInfo
+    />
+
+    <!-- Header -->
+    <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
+        <td>
+          <common-default-header-block
+            name=newsletter.name
+            href=website.get("origin")
+            image-src="/files/base/indm/all/image/static/logos/TIM_Final_Food.jpeg"
+            bg-color="#ffffff"
+          />
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+            <tr>
+              <td bgcolor="#000000" width="134" height="20" align="left" valign="middle">
+                <div style=`${blackBarText} text-transform: uppercase;`>
+                  &nbsp; ${date.format("MMMM D, YYYY")}
+                </div>
+              </td>
+              <td>
+                <marko-newsletter-imgix
+                  src="/files/base/newsletter/header-slanted_left.png"
+                  options={ w: 166, h: 20 }
+                  alt=""
+                  attrs={ border: 0, align: "left", width: 166, height: 20 }>
+                </marko-newsletter-imgix>
+                <marko-newsletter-imgix
+                  src="/files/base/newsletter/header-slanted_right.png"
+                  options={ w: 330, h: 20 }
+                  alt=""
+                  class="mobileHide"
+                  attrs={ border: 0, align: "left", width: 330, height: 20 }>
+                </marko-newsletter-imgix>
+              </td>
+            </tr>
+          </common-table>
+        </td>
+      </tr>
+      <tr>
+        <td>&nbsp;</td>
+      </tr>
+    </common-table>
+
+    <!-- Featured Full -->
+    <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td>
+          <marko-web-query|{ nodes }| name="newsletter-scheduled-content" params={
+            date: date.valueOf(),
+            newsletterId: newsletter.id,
+            sectionId: 86457,
+            limit: 1,
+            queryFragment: contentList,
+          }>
+            <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+              <tr>
+                <td style=`${titleStyle}`>
+                  Featured Story
+                </td>
+              </tr>
+              <tr>
+                <td>&nbsp;</td>
+              </tr>
+            </common-table>
+            <for|node| of=nodes>
+              <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                  $ const imgWaterMarkOptions = waterMarkDisplay({ node, newsletter, markWidth: 90, markHeight: 90 });
+                  $ const imgOptions = {
+                    w: 630,
+                    ...imgWaterMarkOptions
+                  };
+                <marko-newsletter-imgix
+                  src=image.src
+                  alt=image.alt
+                  options=imgOptions
+                  class="main"
+                  attrs={ border: 0, width: 630 }
+                >
+                  <@link href=node.siteContext.url target="_blank" />
+                </marko-newsletter-imgix>
+              </marko-core-obj-value>
+
+              <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "5px", "text-align": "left" } } >
+                <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+              </marko-core-obj-text>
+              <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+            </for>
+          </marko-web-query>
+        </td>
+      </tr>
+      <tr>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
+        <td><hr></td>
+      </tr>
+    </common-table>
+
+    <!-- Featured Split Left||Right -->
+    <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
+        <td>
+
+          <!-- Left Query Wrapper -->
+          <marko-web-query|{ nodes }| name="newsletter-scheduled-content" params={
+            date: date.valueOf(),
+            newsletterId: newsletter.id,
+            sectionId: 86456,
+            queryFragment: contentList,
+          }>
+
+            <!-- Left Wrapping Table -->
+            <common-table width="300" style="border-collapse:collapse;" align="left" class="main" padding=0 spacing=0>
+              <tr>
+                <td valign="top">
+                  <for|node| of=nodes>
+                    <common-table width="300" style="border-collapse:collapse;" align="left" class="left" padding=0 spacing=0>
+                      <tr>
+                        <td>
+                          <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                            $ const imgWaterMarkOptions = waterMarkDisplay({ node, newsletter, markWidth: 90, markHeight: 90 });
+                            $ const imgOptions = {
+                              w: 330,
+                              ...imgWaterMarkOptions
+                            };
+                            <marko-newsletter-imgix
+                              src=image.src
+                              alt=image.alt
+                              options=imgOptions
+                              class="main"
+                              attrs={ border: 0, width: 300 }
+                            >
+                              <@link href=node.siteContext.url target="_blank" />
+                            </marko-newsletter-imgix>
+                          </marko-core-obj-value>
+
+                          <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "5px", "text-align": "left" } } >
+                            <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+                          </marko-core-obj-text>
+                          <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>&nbsp;</td>
+                      </tr>
+                    </common-table>
+                  </for>
+                </td>
+              </tr>
+            </common-table>
+          </marko-web-query>
+
+          <!-- Right Query Wrapper -->
+          <marko-web-query|{ nodes }| name="newsletter-scheduled-content" params={
+            date: date.valueOf(),
+            newsletterId: newsletter.id,
+            sectionId: 86459,
+            queryFragment: contentList,
+          }>
+            <!-- Right Wrapping Table -->
+            <common-table width="300" style="border-collapse:collapse;" align="right" class="main" padding=0 spacing=0>
+              <tr>
+                <td valign="top">
+                  <for|node| of=nodes>
+                    <common-table width="280" style="border-collapse:collapse;" align="left" class="right" padding=10 spacing=0>
+                      <tr>
+                        <td bgcolor="#ecedee">
+                          <marko-core-obj-text obj=node field="name">
+                            <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+                          </marko-core-obj-text>
+                          <common-table
+                            style="margin:10px 10px 0 0;"
+                            align="left"
+                            class="left"
+                            padding=0
+                            spacing=0
+                          >
+                            <tr>
+                              <td>
+                                <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                                  $ const imgWaterMarkOptions = waterMarkDisplay({ node, newsletter, markWidth: 45, markHeight: 45 });
+                                  $ const imgOptions = {
+                                    w: 330,
+                                    ...imgWaterMarkOptions
+                                  };
+                                  <marko-newsletter-imgix
+                                    src=image.src
+                                    alt=image.alt
+                                    options=imgOptions
+                                    class="main"
+                                    attrs={ border: 0, width: 150 }
+                                  >
+                                    <@link href=node.siteContext.url target="_blank" />
+                                  </marko-newsletter-imgix>
+                                </marko-core-obj-value>
+                              </td>
+                            </tr>
+                          </common-table>
+
+                          <marko-core-obj-text tag="div" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
+
+                          <common-table align="right" class="main" padding=0 spacing=0>
+                            <tr>
+                              <td style=`${textAdButtonStyle}`>
+                                <marko-core-obj-text obj=node field="linkText" html=true >
+                                  <@link href=node.siteContext.url target="_blank" attrs={ style: textAdButtonLinkStyle } />
+                                </marko-core-obj-text>
+                              </td>
+                            </tr>
+                          </common-table>
+                        </td>
+                      </tr>
+                    </common-table>
+                    <common-table width="100%" align="center" class="center" >
+                      <tr>
+                        <td>&nbsp;</td>
+                      </tr>
+                    </common-table>
+                  </for>
+                </td>
+              </tr>
+            </common-table>
+          </marko-web-query>
+
+        </td>
+      </tr>
+
+      <tr>
+        <td><hr></td>
+      </tr>
+    </common-table>
+
+    <!-- Featured Split Left||Right -->
+    <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
+        <td>
+
+          <!-- Left Query Wrapper -->
+          <marko-web-query|{ nodes }| name="newsletter-scheduled-content" params={
+            date: date.valueOf(),
+            newsletterId: newsletter.id,
+            sectionId: 86458,
+            queryFragment: contentList,
+          }>
+            <for|node| of=nodes>
+              <if(node.type !== 'text-ad')>
+                <!-- Left Wrapping Table -->
+                <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+                  <tr>
+                    <td valign="top">
+                      <common-table style="margin-right: 10px;" align="left" class="left" padding=0 spacing=0>
+                        <tr>
+                          <td>
+                            <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                                $ const imgWaterMarkOptions = waterMarkDisplay({ node, newsletter, markWidth: 45, markHeight: 45 });
+                                $ const imgOptions = {
+                                  w: 330,
+                                  ...imgWaterMarkOptions
+                                };
+                              <marko-newsletter-imgix
+                                src=image.src
+                                alt=image.alt
+                                options=imgOptions
+                                class="main"
+                                attrs={ border: 0, width: 150 }
+                              >
+                                <@link href=node.siteContext.url target="_blank" />
+                              </marko-newsletter-imgix>
+                            </marko-core-obj-value>
+                          </td>
+                        </tr>
+                      </common-table>
+                      <marko-core-obj-text obj=node field="name" >
+                        <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+                      </marko-core-obj-text>
+                      <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>&nbsp;</td>
+                  </tr>
+                </common-table>
+              </if>
+              <else-if(node.type === 'text-ad')>
+                <!-- Left Wrapping Table -->
+
+                <common-table width="630" style="border-collapse:collapse;" align="left" class="main" padding=10 spacing=0>
+                  <tr>
+                    <td bgcolor="#ecedee">
+                      <marko-core-obj-text obj=node field="name">
+                        <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+                      </marko-core-obj-text>
+                      <common-table
+                        style="margin:10px 10px 0 0;"
+                        align="left"
+                        class="left"
+                        padding=5
+                        spacing=0
+                      >
+                        <tr>
+                          <td>
+                            <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                              <marko-newsletter-imgix
+                                src=image.src
+                                alt=image.alt
+                                options={ w: 330 }
+                                class="main"
+                                attrs={ border: 0, width: 150 }
+                              >
+                                <@link href=node.siteContext.url target="_blank" />
+                              </marko-newsletter-imgix>
+                            </marko-core-obj-value>
+                          </td>
+                        </tr>
+                      </common-table>
+
+                      <marko-core-obj-text tag="div" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
+                      <common-table align="right" class="main" padding=0 spacing=0>
+                        <tr>
+                          <td style=`${textAdButtonStyle}`>
+                            <marko-core-obj-text obj=node field="linkText" html=true >
+                              <@link href=node.siteContext.url target="_blank" attrs={ style: textAdButtonLinkStyle } />
+                            </marko-core-obj-text>
+                          </td>
+                        </tr>
+                      </common-table>
+                    </td>
+                  </tr>
+
+                </common-table>
+                <common-table width="630" style="border-collapse:collapse;" align="left" class="main" padding=0 spacing=0>
+                  <tr>
+                    <td>&nbsp;</td>
+                  </tr>
+                </common-table>
+
+              </else-if>
+            </for>
+          </marko-web-query>
+        </td>
+      </tr>
+    </common-table>
+
+    <!-- Footer/OptOut -->
+    <common-default-footer-block />
+
+  </@body>
+</marko-newsletter-root>

--- a/tenants/multi/templates/ien-weekly-tim-podcast.marko
+++ b/tenants/multi/templates/ien-weekly-tim-podcast.marko
@@ -1,0 +1,151 @@
+import contentList from "@industrial-media/common/graphql/fragments/content-list";
+
+$ const { website, config } = out.global;
+$ const { newsletter, date, dateInfo } = data;
+$ const socialMediaProviders = config.getAsArray('ien.socialMediaLinks');
+$ const primaryColor = "#ee0228";
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-static-styles />
+  </@head>
+  <@body style="margin: 0px !important;">
+    <tenant-banner-element
+      newsletter=newsletter
+      date=date
+      date-info=dateInfo
+    />
+
+    <!-- Header -->
+    <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td>&nbsp;</td>
+      </tr>
+      <tr style="background-color:#ffffff">
+        <td align="left">
+          <common-table width="300" border="0" padding=0 spacing=0 align="left" class="main" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;">
+            <tr>
+              <td>
+                <marko-newsletter-imgix
+                  src="/files/base/indm/all/image/static/logos/TIM_Final_IEN.jpeg"
+                  alt="DDT Today"
+                  options={ w: 340, h: 100 }
+                  class="main"
+                  attrs={ border: 0, width: 340}
+                >
+                  <@link href=website.get("origin") target="_blank" />
+                </marko-newsletter-imgix>
+              </td>
+            </tr>
+          </common-table>
+          <common-table width="290" border="0" padding=5 spacing=0 align="right" class="mobileHide" style="padding-top:10px;">
+            <tr>
+              <td height="20" align="right">
+                <common-table width="100%" border="0" spacing=0 padding=0>
+                  <tr style="text-decoration: none !important; font-size: 11px; font-family: Arial, Helvetica, sans-serif; color: #000000; font-weight: bold;">
+                    <td align="right" style="color:#000000; padding-right:20px;">
+                      ${date.format("MMMM DD, YYYY")}
+                    </td>
+                  </tr>
+                </common-table>
+              </td>
+            </tr>
+            <tr>
+              <td align="right" valign="bottom">
+                <for|socialLinks| of=socialMediaProviders>
+                  <marko-newsletter-imgix
+                    src=`/files/base/newsletter/${socialLinks.provider}-black-round.png`
+                    alt=socialLinks.provider
+                    options={ w: 40 }
+                    attrs={ border: 0, width: 40 }
+                  >
+                    <@link href=socialLinks.href title=socialLinks.title target="_blank" />
+                  </marko-newsletter-imgix>
+                  &nbsp;&nbsp;&nbsp;
+                </for>
+              </td>
+            </tr>
+          </common-table>
+        </td>
+      </tr>
+      <tr>
+        <td><hr></td>
+      </tr>
+      <tr>
+        <td>&nbsp;</td>
+      </tr>
+    </common-table>
+
+    <!-- Content -->
+    <common-featured-full-block
+      section-id=86461,
+      limit=1,
+      title="FEATURED STORY",
+      date=date,
+      newsletter=newsletter,
+      primary-color=primaryColor,
+      hr-below=true,
+    />
+
+    <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td>
+          <common-featured-half-block
+            section-id=86460,
+            limit=2,
+            date=date,
+            newsletter=newsletter,
+            primary-color=primaryColor,
+            align="left",
+          />
+          <common-promotion-half-block
+            section-id=86463,
+            limit=2,
+            date=date,
+            primary-color=primaryColor,
+            newsletter=newsletter,
+            align="right",
+          />
+        </td>
+      </tr>
+    </common-table>
+
+    <common-table width="630" padding=0 spacing=0 align="center" style="border-collapse:collapse;" class="main">
+      <tr>
+        <td>
+          <marko-newsletter-imgix
+            src="/files/base/newsletter/slanted.png"
+            options={ w: 315, h: 10 }
+            alt=""
+            attrs={ border: 0, align: "left", width: 315, height: 10 }>
+          </marko-newsletter-imgix>
+          <marko-newsletter-imgix
+            src="/files/base/newsletter/slanted.png"
+            options={ w: 315, h: 10 }
+            alt=""
+            class="mobileHide"
+            attrs={ border: 0, align: "left", width: 315, height: 10 }>
+          </marko-newsletter-imgix>
+        </td>
+      </tr>
+      <tr>
+          <td>&nbsp;</td>
+      </tr>
+    </common-table>
+
+    <common-feed-full-block
+      section-id=86462,
+      date=date,
+      newsletter=newsletter,
+      primary-color=primaryColor,
+    />
+
+    <!-- Footer/OptOut -->
+    <common-default-footer-block />
+
+  </@body>
+</marko-newsletter-root>


### PR DESCRIPTION
**This replicates the weekly, updated headers for DDT, FM, IEN**
<img width="1515" alt="Screen Shot 2023-07-12 at 1 25 19 PM" src="https://github.com/parameter1/industrial-media-newsletters/assets/64623209/44222886-6f32-43c3-b41e-718266a198af">
<img width="713" alt="Screen Shot 2023-07-12 at 1 25 45 PM" src="https://github.com/parameter1/industrial-media-newsletters/assets/64623209/66e04a87-a634-44c7-b513-60740d6d9489">
<img width="824" alt="Screen Shot 2023-07-12 at 1 36 15 PM" src="https://github.com/parameter1/industrial-media-newsletters/assets/64623209/57d7eee5-eacb-4281-883d-29f8e1f66b40">
