### PR TITLE
Adjust styling for security breach updated logo

### DIFF
--- a/tenants/multi/templates/manufacturing-security-breach.marko
+++ b/tenants/multi/templates/manufacturing-security-breach.marko
@@ -75,7 +75,7 @@ $ const textAdButtonLinkStyle = {
                     <td align="left" valign="top">
                       <marko-newsletter-imgix
                         src="/files/base/indm/all/image/static/logos/securitybreachupdated.png"
-                        attrs={fit:"clip", width:630, height:230}
+                        attrs={fit:"clip", width:630, height:130}
                       >
                         <@link href=website.get("origin") target="_blank" />
                       </marko-newsletter-imgix>


### PR DESCRIPTION
<img width="849" alt="Screen Shot 2023-12-07 at 6 06 51 PM" src="https://github.com/parameter1/industrial-media-newsletters/assets/64623209/87573314-cd08-4d6c-8dea-961b290722b9">
