### PR TITLE
Add additional styling to security breach header

### DIFF
--- a/tenants/multi/templates/manufacturing-security-breach.marko
+++ b/tenants/multi/templates/manufacturing-security-breach.marko
@@ -74,8 +74,9 @@ $ const textAdButtonLinkStyle = {
                   <tr>
                     <td align="left" valign="top">
                       <marko-newsletter-imgix
-                        src="/files/base/indm/all/image/static/logos/securitybreachupdated.png"
-                        attrs={fit:"clip", width:630, height:130}
+                        src="/files/base/indm/all/image/static/logos/ot-security.jpeg"
+                        options={w: 630, h: 115 }
+                        attrs={width: 630, height: 115 }
                       >
                         <@link href=website.get("origin") target="_blank" />
                       </marko-newsletter-imgix>

--- a/tenants/multi/templates/manufacturing-security-breach.marko
+++ b/tenants/multi/templates/manufacturing-security-breach.marko
@@ -75,8 +75,8 @@ $ const textAdButtonLinkStyle = {
                     <td align="left" valign="top">
                       <marko-newsletter-imgix
                         src="/files/base/indm/all/image/static/logos/ot-security.jpeg"
-                        options={w: 630, h: 115 }
-                        attrs={width: 630, height: 115 }
+                        options={ w: 630, h: 115 }
+                        attrs={ width: 630, height: 115 }
                       >
                         <@link href=website.get("origin") target="_blank" />
                       </marko-newsletter-imgix>


### PR DESCRIPTION
I'm not sure what else I can adjust to 'fix the blurriness' [https://trello.com/c/3slZgOtn/448-newsletter-creation-security-breach](url)
<img width="864" alt="Screen Shot 2023-12-12 at 10 25 55 AM" src="https://github.com/parameter1/industrial-media-newsletters/assets/64623209/864710f7-ad6a-472c-a3f4-a650a9a16628">
