### PR TITLE
Additional image width prop adjustment to match render & display properties

### DIFF
--- a/packages/common/components/blocks/content/feed-full.marko
+++ b/packages/common/components/blocks/content/feed-full.marko
@@ -200,7 +200,7 @@ $ const textAdButtonLinkStyle = {
                                 <marko-newsletter-imgix
                                   src=image.src
                                   alt=image.alt
-                                  options={ w: 330 }
+                                  options={ w: 150 }
                                   attrs={ border: 0, width: 150 }
                                 >
                                   <@link href=node.siteContext.url target="_blank" />

--- a/tenants/multi/templates/fm-today.marko
+++ b/tenants/multi/templates/fm-today.marko
@@ -247,7 +247,7 @@ $ const textAdButtonLinkStyle = {
                                 <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
                                   $ const imgWaterMarkOptions = waterMarkDisplay({ node, newsletter, markWidth: 45, markHeight: 45 });
                                   $ const imgOptions = {
-                                    w: 330,
+                                    w: 150,
                                     ...imgWaterMarkOptions
                                   };
                                   <marko-newsletter-imgix
@@ -373,7 +373,7 @@ $ const textAdButtonLinkStyle = {
                               <marko-newsletter-imgix
                                 src=image.src
                                 alt=image.alt
-                                options={ w: 330 }
+                                options={ w: 150 }
                                 class="main"
                                 attrs={ border: 0, width: 150 }
                               >

--- a/tenants/multi/templates/fm-weekly-tim-podcast.marko
+++ b/tenants/multi/templates/fm-weekly-tim-podcast.marko
@@ -244,7 +244,7 @@ $ const textAdButtonLinkStyle = {
                                 <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
                                   $ const imgWaterMarkOptions = waterMarkDisplay({ node, newsletter, markWidth: 45, markHeight: 45 });
                                   $ const imgOptions = {
-                                    w: 330,
+                                    w: 150,
                                     ...imgWaterMarkOptions
                                   };
                                   <marko-newsletter-imgix
@@ -370,7 +370,7 @@ $ const textAdButtonLinkStyle = {
                               <marko-newsletter-imgix
                                 src=image.src
                                 alt=image.alt
-                                options={ w: 330 }
+                                options={ w: 150 }
                                 class="main"
                                 attrs={ border: 0, width: 150 }
                               >

--- a/tenants/multi/templates/fm-weekly.marko
+++ b/tenants/multi/templates/fm-weekly.marko
@@ -247,7 +247,7 @@ $ const textAdButtonLinkStyle = {
                                 <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
                                   $ const imgWaterMarkOptions = waterMarkDisplay({ node, newsletter, markWidth: 45, markHeight: 45 });
                                   $ const imgOptions = {
-                                    w: 330,
+                                    w: 150,
                                     ...imgWaterMarkOptions
                                   };
                                   <marko-newsletter-imgix
@@ -373,7 +373,7 @@ $ const textAdButtonLinkStyle = {
                               <marko-newsletter-imgix
                                 src=image.src
                                 alt=image.alt
-                                options={ w: 330 }
+                                options={ w: 150 }
                                 class="main"
                                 attrs={ border: 0, width: 150 }
                               >

--- a/tenants/multi/templates/id-ma-monthly.marko
+++ b/tenants/multi/templates/id-ma-monthly.marko
@@ -247,7 +247,7 @@ $ const textAdButtonLinkStyle = {
                                 <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
                                   $ const imgWaterMarkOptions = waterMarkDisplay({ node, newsletter, markWidth: 45, markHeight: 45 });
                                   $ const imgOptions = {
-                                    w: 330,
+                                    w: 150,
                                     ...imgWaterMarkOptions
                                   };
                                   <marko-newsletter-imgix
@@ -373,7 +373,7 @@ $ const textAdButtonLinkStyle = {
                               <marko-newsletter-imgix
                                 src=image.src
                                 alt=image.alt
-                                options={ w: 330 }
+                                options={ w: 150 }
                                 class="main"
                                 attrs={ border: 0, width: 150 }
                               >

--- a/tenants/multi/templates/id-today.marko
+++ b/tenants/multi/templates/id-today.marko
@@ -247,7 +247,7 @@ $ const textAdButtonLinkStyle = {
                                 <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
                                   $ const imgWaterMarkOptions = waterMarkDisplay({ node, newsletter, markWidth: 45, markHeight: 45 });
                                   $ const imgOptions = {
-                                    w: 330,
+                                    w: 150,
                                     ...imgWaterMarkOptions
                                   };
                                   <marko-newsletter-imgix
@@ -373,7 +373,7 @@ $ const textAdButtonLinkStyle = {
                               <marko-newsletter-imgix
                                 src=image.src
                                 alt=image.alt
-                                options={ w: 330 }
+                                options={ w: 150 }
                                 class="main"
                                 attrs={ border: 0, width: 150 }
                               >

--- a/tenants/multi/templates/impo-insider.marko
+++ b/tenants/multi/templates/impo-insider.marko
@@ -248,7 +248,7 @@ $ const textAdButtonLinkStyle = {
                                 <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
                                   $ const imgWaterMarkOptions = waterMarkDisplay({ node, newsletter, markWidth: 45, markHeight: 45 });
                                   $ const imgOptions = {
-                                    w: 330,
+                                    w: 150,
                                     ...imgWaterMarkOptions
                                   };
                                   <marko-newsletter-imgix
@@ -374,7 +374,7 @@ $ const textAdButtonLinkStyle = {
                               <marko-newsletter-imgix
                                 src=image.src
                                 alt=image.alt
-                                options={ w: 330 }
+                                options={ w: 150 }
                                 class="main"
                                 attrs={ border: 0, width: 150 }
                               >

--- a/tenants/multi/templates/imts-weekly.marko
+++ b/tenants/multi/templates/imts-weekly.marko
@@ -247,7 +247,7 @@ $ const textAdButtonLinkStyle = {
                                 <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
                                   $ const imgWaterMarkOptions = waterMarkDisplay({ node, newsletter, markWidth: 45, markHeight: 45 });
                                   $ const imgOptions = {
-                                    w: 330,
+                                    w: 150,
                                     ...imgWaterMarkOptions
                                   };
                                   <marko-newsletter-imgix
@@ -373,7 +373,7 @@ $ const textAdButtonLinkStyle = {
                               <marko-newsletter-imgix
                                 src=image.src
                                 alt=image.alt
-                                options={ w: 330 }
+                                options={ w: 150 }
                                 class="main"
                                 attrs={ border: 0, width: 150 }
                               >

--- a/tenants/multi/templates/manufacturing-today-safety.marko
+++ b/tenants/multi/templates/manufacturing-today-safety.marko
@@ -247,7 +247,7 @@ $ const textAdButtonLinkStyle = {
                                 <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
                                   $ const imgWaterMarkOptions = waterMarkDisplay({ node, newsletter, markWidth: 45, markHeight: 45 });
                                   $ const imgOptions = {
-                                    w: 330,
+                                    w: 150,
                                     ...imgWaterMarkOptions
                                   };
                                   <marko-newsletter-imgix
@@ -373,7 +373,7 @@ $ const textAdButtonLinkStyle = {
                               <marko-newsletter-imgix
                                 src=image.src
                                 alt=image.alt
-                                options={ w: 330 }
+                                options={ w: 150 }
                                 class="main"
                                 attrs={ border: 0, width: 150 }
                               >

--- a/tenants/multi/templates/manufacturing-today.marko
+++ b/tenants/multi/templates/manufacturing-today.marko
@@ -247,7 +247,7 @@ $ const textAdButtonLinkStyle = {
                                 <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
                                   $ const imgWaterMarkOptions = waterMarkDisplay({ node, newsletter, markWidth: 45, markHeight: 45 });
                                   $ const imgOptions = {
-                                    w: 330,
+                                    w: 150,
                                     ...imgWaterMarkOptions
                                   };
                                   <marko-newsletter-imgix
@@ -373,7 +373,7 @@ $ const textAdButtonLinkStyle = {
                               <marko-newsletter-imgix
                                 src=image.src
                                 alt=image.alt
-                                options={ w: 330 }
+                                options={ w: 150 }
                                 class="main"
                                 attrs={ border: 0, width: 150 }
                               >

--- a/tenants/multi/templates/manufacturing-weekly-comp.marko
+++ b/tenants/multi/templates/manufacturing-weekly-comp.marko
@@ -252,7 +252,7 @@ $ const textAdButtonLinkStyle = {
                                 <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
                                   $ const imgWaterMarkOptions = waterMarkDisplay({ node, newsletter, markWidth: 45, markHeight: 45 });
                                   $ const imgOptions = {
-                                    w: 330,
+                                    w: 150,
                                     ...imgWaterMarkOptions
                                   };
                                   <marko-newsletter-imgix
@@ -378,7 +378,7 @@ $ const textAdButtonLinkStyle = {
                               <marko-newsletter-imgix
                                 src=image.src
                                 alt=image.alt
-                                options={ w: 330 }
+                                options={ w: 150 }
                                 class="main"
                                 attrs={ border: 0, width: 150 }
                               >

--- a/tenants/multi/templates/mbt-today.marko
+++ b/tenants/multi/templates/mbt-today.marko
@@ -247,7 +247,7 @@ $ const textAdButtonLinkStyle = {
                                 <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
                                   $ const imgWaterMarkOptions = waterMarkDisplay({ node, newsletter, markWidth: 45, markHeight: 45 });
                                   $ const imgOptions = {
-                                    w: 330,
+                                    w: 150,
                                     ...imgWaterMarkOptions
                                   };
                                   <marko-newsletter-imgix
@@ -373,7 +373,7 @@ $ const textAdButtonLinkStyle = {
                               <marko-newsletter-imgix
                                 src=image.src
                                 alt=image.alt
-                                options={ w: 330 }
+                                options={ w: 150 }
                                 class="main"
                                 attrs={ border: 0, width: 150 }
                               >

--- a/tenants/multi/templates/newswire.marko
+++ b/tenants/multi/templates/newswire.marko
@@ -247,7 +247,7 @@ $ const textAdButtonLinkStyle = {
                                 <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
                                   $ const imgWaterMarkOptions = waterMarkDisplay({ node, newsletter, markWidth: 45, markHeight: 45 });
                                   $ const imgOptions = {
-                                    w: 330,
+                                    w: 150,
                                     ...imgWaterMarkOptions
                                   };
                                   <marko-newsletter-imgix
@@ -373,7 +373,7 @@ $ const textAdButtonLinkStyle = {
                               <marko-newsletter-imgix
                                 src=image.src
                                 alt=image.alt
-                                options={ w: 330 }
+                                options={ w: 150 }
                                 class="main"
                                 attrs={ border: 0, width: 150 }
                               >

--- a/tenants/multi/templates/ot-security-update-weekly.marko
+++ b/tenants/multi/templates/ot-security-update-weekly.marko
@@ -266,7 +266,7 @@ $ const textAdButtonLinkStyle = {
                                 <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
                                   $ const imgWaterMarkOptions = waterMarkDisplay({ node, newsletter, markWidth: 45, markHeight: 45 });
                                   $ const imgOptions = {
-                                    w: 330,
+                                    w: 150,
                                     ...imgWaterMarkOptions
                                   };
                                   <marko-newsletter-imgix
@@ -392,7 +392,7 @@ $ const textAdButtonLinkStyle = {
                               <marko-newsletter-imgix
                                 src=image.src
                                 alt=image.alt
-                                options={ w: 330 }
+                                options={ w: 150 }
                                 class="main"
                                 attrs={ border: 0, width: 150 }
                               >


### PR DESCRIPTION
Ensure that the requested image is the same as the display be rendered.

update w: 330 to w: 150

$ const imgOptions = {
  w: 150,
  ...imgWaterMarkOptions
};
<marko-newsletter-imgix
  src=image.src
  alt=image.alt
  options=imgOptions
  class="main"
  attrs={ border: 0, width: 150 }
>