### PR TITLE
Remove passing through ‘primary-color’ for all Showcase newsletters

### DIFF
--- a/tenants/multi/templates/fm-product-showcase.marko
+++ b/tenants/multi/templates/fm-product-showcase.marko
@@ -118,7 +118,6 @@ $ const teaserStyle = {
       title="FEATURED PRODUCT VIDEO",
       date=date,
       newsletter=newsletter,
-      primary-color=primaryColor,
       hr-below=true,
     />
 

--- a/tenants/multi/templates/food-video-showcase.marko
+++ b/tenants/multi/templates/food-video-showcase.marko
@@ -59,7 +59,6 @@ $ const teaserStyle = {
       title="FEATURED PRODUCT VIDEO",
       date=date,
       newsletter=newsletter,
-      primary-color=primaryColor,
       hr-below=true,
     />
 

--- a/tenants/multi/templates/id-product-showcase.marko
+++ b/tenants/multi/templates/id-product-showcase.marko
@@ -120,7 +120,6 @@ $ const teaserStyle = {
       title="FEATURED PRODUCT VIDEO",
       date=date,
       newsletter=newsletter,
-      primary-color=primaryColor,
       hr-below=true,
     />
 

--- a/tenants/multi/templates/id-video-showcase.marko
+++ b/tenants/multi/templates/id-video-showcase.marko
@@ -59,7 +59,6 @@ $ const teaserStyle = {
       title="FEATURED PRODUCT VIDEO",
       date=date,
       newsletter=newsletter,
-      primary-color=primaryColor,
       hr-below=true,
     />
 

--- a/tenants/multi/templates/impo-mag-product-showcase.marko
+++ b/tenants/multi/templates/impo-mag-product-showcase.marko
@@ -117,7 +117,6 @@ $ const teaserStyle = {
       title="FEATURED PRODUCT VIDEO",
       date=date,
       newsletter=newsletter,
-      primary-color=primaryColor,
       hr-below=true,
     />
 

--- a/tenants/multi/templates/impo-video-showcase.marko
+++ b/tenants/multi/templates/impo-video-showcase.marko
@@ -59,7 +59,6 @@ $ const teaserStyle = {
       title="FEATURED PRODUCT VIDEO",
       date=date,
       newsletter=newsletter,
-      primary-color=primaryColor,
       hr-below=true,
     />
 

--- a/tenants/multi/templates/manufacturing-product-showcase.marko
+++ b/tenants/multi/templates/manufacturing-product-showcase.marko
@@ -117,7 +117,6 @@ $ const teaserStyle = {
       title="FEATURED PRODUCT VIDEO",
       date=date,
       newsletter=newsletter,
-      primary-color=primaryColor,
       hr-below=true,
     />
 

--- a/tenants/multi/templates/mbt-product-showcase.marko
+++ b/tenants/multi/templates/mbt-product-showcase.marko
@@ -117,7 +117,6 @@ $ const teaserStyle = {
       title="FEATURED PRODUCT VIDEO",
       date=date,
       newsletter=newsletter,
-      primary-color=primaryColor,
       hr-below=true,
     />
 

--- a/tenants/multi/templates/mdd-video-showcase.marko
+++ b/tenants/multi/templates/mdd-video-showcase.marko
@@ -59,7 +59,6 @@ $ const teaserStyle = {
       title="FEATURED PRODUCT VIDEO",
       date=date,
       newsletter=newsletter,
-      primary-color=primaryColor,
       hr-below=true,
     />
 

--- a/tenants/multi/templates/product-showcase.marko
+++ b/tenants/multi/templates/product-showcase.marko
@@ -108,7 +108,6 @@ $ const teaserStyle = {
       title="FEATURED PRODUCT VIDEO",
       date=date,
       newsletter=newsletter,
-      primary-color=primaryColor,
       hr-below=true,
     />
 

--- a/tenants/multi/templates/video-showcase.marko
+++ b/tenants/multi/templates/video-showcase.marko
@@ -59,7 +59,6 @@ $ const teaserStyle = {
       title="FEATURED PRODUCT VIDEO",
       date=date,
       newsletter=newsletter,
-      primary-color=primaryColor,
       hr-below=true,
     />
 


### PR DESCRIPTION
<img width="994" alt="Screenshot 2024-05-20 at 12 03 53 PM" src="https://github.com/parameter1/industrial-media-newsletters/assets/64623209/39b0b20c-2ab5-4d9f-91cd-9fee287cdf9c">
