### PR TITLE
Use <div> to reduce spacing between title and image

### DIFF
--- a/packages/common/components/blocks/ad/half-native.marko
+++ b/packages/common/components/blocks/ad/half-native.marko
@@ -83,13 +83,11 @@ $ const textAdButtonLinkStyle = {
 <common-table class="main" width="280" style="border-collapse:collapse;" align=align padding=10 spacing=0>
   <tr>
     <td bgcolor="#ecedee">
-      <a href=contextualUrl target="_blank" style=contentLinkStyle ...linkAttrs>
-        $!{content.name}
-      </a>
-    </td>
-  </tr>
-  <tr>
-    <td bgcolor="#ecedee">
+      <div>
+        <a href=contextualUrl target="_blank" style=contentLinkStyle ...linkAttrs>
+          $!{content.name}
+        </a>
+      </div>
       <common-table
         style="margin:10px 10px 0 0;"
         align="left"


### PR DESCRIPTION
PROD:
<img width="349" alt="Screenshot 2025-01-27 at 11 44 44 AM" src="https://github.com/user-attachments/assets/8a1e884d-7dff-4033-a38d-bde3967cbb26" />

DEV:
<img width="323" alt="Screenshot 2025-01-27 at 11 44 51 AM" src="https://github.com/user-attachments/assets/1b8c6573-3273-40a1-8afd-c45af8a1837d" />
