### PR TITLE
Grab `linkAttrs` over `link.attrs` for Mindful Native Ads

### DIFF
--- a/packages/common/components/blocks/ad/full-native.marko
+++ b/packages/common/components/blocks/ad/full-native.marko
@@ -24,7 +24,7 @@ $ const imgLinkStyles = {
 }
 
 $ const linkAttrs = {
-  ...(getAsObject(input, "link.attrs")),
+  ...(getAsObject(input, "linkAttrs")),
   ...(creativeId && { 'data-mindful-creative-id': creativeId }),
   ...(tenant && { 'data-mindful-tenant': tenant }),
 };

--- a/packages/common/components/blocks/ad/half-native.marko
+++ b/packages/common/components/blocks/ad/half-native.marko
@@ -25,7 +25,7 @@ $ const imgLinkStyles = {
 }
 
 $ const linkAttrs = {
-  ...(getAsObject(input, "link.attrs")),
+  ...(getAsObject(input, "linkAttrs")),
   ...(creativeId && { 'data-mindful-creative-id': creativeId }),
   ...(tenant && { 'data-mindful-tenant': tenant }),
 };

--- a/packages/common/components/blocks/ad/video-native.marko
+++ b/packages/common/components/blocks/ad/video-native.marko
@@ -22,7 +22,7 @@ $ const imgLinkStyles = {
 }
 
 $ const linkAttrs = {
-  ...(getAsObject(input, "link.attrs")),
+  ...(getAsObject(input, "linkAttrs")),
   ...(creativeId && { 'data-mindful-creative-id': creativeId }),
   ...(tenant && { 'data-mindful-tenant': tenant }),
 };


### PR DESCRIPTION
Couple examples of corrected items:
![Screenshot from 2025-04-04 13-34-45](https://github.com/user-attachments/assets/555c0d58-1796-4927-a35a-854dc28a99c1)
![Screenshot from 2025-04-04 13-34-50](https://github.com/user-attachments/assets/7b7902ad-ccd7-495a-b2eb-2242a05bfcfa)
![Screenshot from 2025-04-04 13-34-58](https://github.com/user-attachments/assets/0825e7f4-33a4-405d-a382-02e7e2bf422e)


See: https://github.com/parameter1/industrial-media-newsletters/blob/main/packages/common/components/blocks/ad/wrapper.marko#L44 as this is being passed into each of these as `linkAttrs` over a `link` object with subkey of `attrs`.