### PR TITLE
Adjust image size for ADM native ads

### DIFF
--- a/packages/shared/components/blocks/ad/promotion-advertisement.marko
+++ b/packages/shared/components/blocks/ad/promotion-advertisement.marko
@@ -57,12 +57,12 @@ $ const nameLinkAttrs = { style: nameLinkStyles, ...linkAttrs };
         <td align="center" valign="top" dir="rtl">
           <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0">
             <tr>
-              <td align="right" valign="top" width="200" class="wdt" style="padding-left:5px;">
+              <td align="right" valign="top" width="150" class="wdt" style="padding-left:5px;">
                 <marko-core-obj-value|{ value: image }| obj=content field="primaryImage" as="object">
                   <marko-newsletter-imgix
                     src=image.src
                     alt=image.alt
-                    options={ w: 200, h: 133, fit: "crop", auto: "format,compress" }
+                    options={ w: 150, h: 125, fit: "crop", auto: "format,compress" }
                     attrs={ border: 0, style: imgStyles }
                     class="img_resize2"
                   >


### PR DESCRIPTION
<img width="808" height="330" alt="Screenshot 2026-03-20 at 11 26 38 AM" src="https://github.com/user-attachments/assets/b885276a-d197-4fe9-b935-573636061d6b" />
<img width="381" height="264" alt="Screenshot 2026-03-20 at 11 27 06 AM" src="https://github.com/user-attachments/assets/f398ce96-b353-426c-9a29-0afd7da2af53" />
